### PR TITLE
Fix pmap link on http://contributor-covenant.org/

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 			<li><a href="https://www.webmaker.org/">Mozilla Webmaker</a></li>
 			<li><a href="https://github.com/OpenDroneMap/OpenDroneMap">OpenDroneMap</a></li>
 			<li><a href="https://github.com/jordanekay/Ornament">Ornament</a></li>
-			<li><a href="https://github.com/bruceadams/pmap>">pmap</a></li>
+			<li><a href="https://github.com/bruceadams/pmap">pmap</a></li>
 			<li><a href="https://github.com/voormedia/rails-erd">rails-erd</a></li>
 			<li><a href="https://gitlab.com/coraline/snuffle/tree/master">Snuffle</a></li>
 		</ul>


### PR DESCRIPTION
The link to https://github.com/bruceadams/pmap on http://contributor-covenant.org/ is broken due to an additional angle bracket.