### PR TITLE
Add OpenProject to the project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ Please feel free to submit pull requests or open issues to improve the language 
 * [haxe-pixi](https://github.com/adireddy/haxe-pixi)
 * [HTTPotion](https://github.com/myfreeweb/httpotion)
 * [Lotus](http://lotusrb.org/community#code-of-conduct)
+* [OpenProject](https://www.openproject.org/)


### PR DESCRIPTION
This will add OpenProject (https://github.com/opf/openproject) to the project list.