### PR TITLE
Make a v1.1.1 which has 2 slashes in all URLs

### DIFF
--- a/version/1/1/1/code_of_conduct.md
+++ b/version/1/1/1/code_of_conduct.md
@@ -12,4 +12,4 @@ This code of conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.1, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/1/)
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.1, available at [http://contributor-covenant.org/version/1/1/1/](http://contributor-covenant.org/version/1/1/1/)

--- a/version/1/1/1/code_of_conduct.md
+++ b/version/1/1/1/code_of_conduct.md
@@ -1,0 +1,15 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.1, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/1/)

--- a/version/1/1/1/code_of_conduct.txt
+++ b/version/1/1/1/code_of_conduct.txt
@@ -1,0 +1,28 @@
+Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed
+from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant
+(http://contributor-covenant.org), version 1.1.1, available at
+http://contributor-covenant.org/version/1/1/1/

--- a/version/1/1/1/index.htm
+++ b/version/1/1/1/index.htm
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+
+<head>
+  <style>
+    body {
+      font-family: consolas, courier;
+      padding: 4em;
+    }
+    a {
+      color: #990000;
+    }
+  </style>
+</head>
+
+<body>
+
+<h1>Contributor Code of Conduct</h1>
+
+<p>As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.</p>
+
+<p>We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.</p>
+
+<p>Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.</p>
+
+<p>Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.</p>
+
+<p>This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.</p>
+
+<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.</p>
+
+<p>This Code of Conduct is adapted from the Contributor Covenant, version 1.1.1, available from
+<a href="http://contributor-covenant.org/version/1/1/1/">http://contributor-covenant.org/version/1/1/1/</a></p>
+
+</body>


### PR DESCRIPTION
In v1.1.0, there are instances of the URL `http:contributor-covenant.org`. This patch is just replacing all of the `http:contributor-covenant.org` with `http://contributor-covenant.org`