### PR TITLE
Add Composer to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Please feel free to submit pull requests or open issues to improve the language 
 * [chef-rvm](https://github.com/fnichol/chef-rvm)
 * [CloudI](http://cloudi.org/faq.html#2_CodeOfConduct)
 * [CocoaPods](https://github.com/cocoapods/cocoapods)
+* [composer](https://github.com/composer/composer)
 * [Crackle](https://github.com/jordanekay/Crackle)
 * [Eldest Daughter Questionnaire](https://github.com/eldest-daughter/ed-questionnaire)
 * [Exercism.io](https://github.com/exercism/exercism.io)


### PR DESCRIPTION
It mentions the Contributor Covenant here: https://github.com/composer/composer/blob/master/CONTRIBUTING.md

Composer is the defacto standard for managing dependencies in PHP projects, so I'm happy that they are supporting the convenent.