### PR TITLE
Fixed punctuation.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -11,7 +11,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling or insulting/derogatory comments
 * Public or private harassment
 * Publishing other's private information, such as physical or electronic addresses, without explicit permission
-* Other unethical or unprofessional conduct.
+* Other unethical or unprofessional conduct
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
 


### PR DESCRIPTION
The first five items in the list of examples of unacceptable behavior were not trailed by periods, so period at the end of the sixth item stopped the list from being uniform.