### PR TITLE
Add diet to include people with specialized diets or dietary restrictions

### DIFF
--- a/version/1/3/0/code_of_conduct.md
+++ b/version/1/3/0/code_of_conduct.md
@@ -7,8 +7,8 @@ documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+identity and expression, sexual orientation, disability, diet, personal
+appearance, body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 

--- a/version/1/3/0/code_of_conduct.txt
+++ b/version/1/3/0/code_of_conduct.txt
@@ -9,7 +9,7 @@ and other activities.
 We are committed to making participation in this project a
 harassment-free experience for everyone, regardless of level of
 experience, gender, gender identity and expression, sexual orientation,
-disability, personal appearance, body size, race, ethnicity, age,
+disability, diet, personal appearance, body size, race, ethnicity, age,
 religion, or nationality.
 
 Examples of unacceptable behavior by participants include:


### PR DESCRIPTION
Add diet to include people with specialized diets or dietary restrictions. This includes people who choose their diet based on personal, ethical, religious, political or medical reasons. This group includes vegans, vegetarians, pescatarian, ḥalāl, kosher, those with food allergies, and yes even omnivores. If anyone has any opposing view points, I only request they be more nuance than the standard "vegans suck".