### PR TITLE
Fixes for the Polish localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 				<li><a href="version/1/3/0/fr/code_of_conduct.md">Français</a></li>
 				<li><a href="version/1/3/0/it/code_of_conduct.md">Italiano</a></li>
 				<li><a href="version/1/3/0/hu/code_of_conduct.md">Magyar</a></li>
-				<li><a href="version/1/3/0/pl/code_of_conduct.md">Polskie</a></li>
+				<li><a href="version/1/3/0/pl/code_of_conduct.md">Polski</a></li>
 				<li><a href="version/1/3/0/pt/code_of_conduct.md">Português</a></li>
 				<li><a href="version/1/3/0/pt_br/code_of_conduct.md">Português do Brasil</a></li>
 				<li><a href="version/1/3/0/ru/code_of_conduct.md">Pусский</a></li>
@@ -54,7 +54,7 @@
 				<li><a href="version/1/3/0/fr/">Français</a></li>
 				<li><a href="version/1/3/0/it/">Italiano</a></li>
 				<li><a href="version/1/3/0/hu/">Magyar</a></li>
-				<li><a href="version/1/3/0/pl/">Polskie</a></li>
+				<li><a href="version/1/3/0/pl/">Polski</a></li>
 				<li><a href="version/1/3/0/pt/">Português</a></li>
 				<li><a href="version/1/3/0/pt_br/">Português do Brasil</a></li>
 				<li><a href="version/1/3/0/ru/">Pусский</a></li>
@@ -66,7 +66,7 @@
 				<li><a href="version/1/3/0/fr/code_of_conduct.txt">Français</a></li>
 				<li><a href="version/1/3/0/it/code_of_conduct.txt">Italiano</a></li>
 				<li><a href="version/1/3/0/hu/code_of_conduct.txt">Magyar</a></li>
-				<li><a href="version/1/3/0/pl/code_of_conduct.txt">Polskie</a></li>
+				<li><a href="version/1/3/0/pl/code_of_conduct.txt">Polski</a></li>
 				<li><a href="version/1/3/0/pt/code_of_conduct.txt">Português</a></li>
 				<li><a href="version/1/3/0/pt_br/code_of_conduct.txt">Português do Brasil</a></li>
 				<li><a href="version/1/3/0/ru/code_of_conduct.txt">Pусский</a></li>

--- a/version/1/3/0/pl/code_of_conduct.md
+++ b/version/1/3/0/pl/code_of_conduct.md
@@ -1,19 +1,19 @@
 # Kodeks postępowania współtwórców
 
-My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez "pull request".
+My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób, które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez pull request.
 
 Pragniemy, aby udział w projekcie był pozbawiony szykanowania ze względu na doświadczenie, płeć, orientację i identyfikację seksualną, stopień niepełnosprawności, wygląd, budowę ciała, kolor skóry, pochodzenie, czy wiek.
 
-Wśród przykładów zachowania którego nie będziemy akceptować są:
+Wśród przykładów zachowania, którego nie będziemy akceptować, są:
 
   * Używanie seksualnego języka i grafik,
   * Ataki osobiste,
-  * "Trollowanie" i obraźliwe bądź urągające komentarze,
+  * Trollowanie i obraźliwe bądź urągające komentarze,
   * Zastraszanie, tak na forum publicznym jak i prywatne,
   * Publikowanie bez wyraźnej zgody informacji osobistych, takich jak: adres fizyczny czy elektroniczny,
   * Inne nieetyczne lub nieprofesjonalne zachowania.
 
-Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do "banowania", tak tymczasowego jak i stałego, osób których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.
+Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do banowania — tak tymczasowego jak i stałego — osób, których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.
 
 Poprzez przyjęcie niniejszego Kodeksu postępowania opiekunowie ślubują, że będą cechować się uczciwością oraz konsekwentnością przy stosowaniu tych zasad w każdym aspekcie swojego działania nad tym projektem. Opiekunowie, który nie będą postępować lub wymagać od innych zachowania zgodnego z Kodeksem mogą zostać stale usunięci z zespołu współtworzącego ten projekt.
 

--- a/version/1/3/0/pl/code_of_conduct.txt
+++ b/version/1/3/0/pl/code_of_conduct.txt
@@ -1,19 +1,19 @@
 Kodeks postępowania współtwórców
 
-My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez "pull request".
+My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób, które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez pull request.
 
 Pragniemy, aby udział w projekcie był pozbawiony szykanowania ze względu na doświadczenie, płeć, orientację i identyfikację seksualną, stopień niepełnosprawności, wygląd, budowę ciała, kolor skóry, pochodzenie, czy wiek.
 
-Wśród przykładów zachowania którego nie będziemy akceptować są:
+Wśród przykładów zachowania, którego nie będziemy akceptować, są:
 
 * Używanie seksualnego języka i grafik,
 * Ataki osobiste,
-* "Trollowanie" i obraźliwe bądź urągające komentarze,
+* Trollowanie i obraźliwe bądź urągające komentarze,
 * Zastraszanie, tak na forum publicznym jak i prywatne,
 * Publikowanie bez wyraźnej zgody informacji osobistych, takich jak: adres fizyczny czy elektroniczny,
 * Inne nieetyczne lub nieprofesjonalne zachowania.
 
-Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do "banowania", tak tymczasowego jak i stałego, osób których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.
+Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do banowania — tak tymczasowego jak i stałego — osób, których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.
 
 Poprzez przyjęcie niniejszego Kodeksu postępowania opiekunowie ślubują, że będą cechować się uczciwością oraz konsekwentnością przy stosowaniu tych zasad w każdym aspekcie swojego działania nad tym projektem. Opiekunowie, który nie będą postępować lub wymagać od innych zachowania zgodnego z Kodeksem mogą zostać stale usunięci z zespołu współtworzącego ten projekt.
 

--- a/version/1/3/0/pl/index.htm
+++ b/version/1/3/0/pl/index.htm
@@ -17,22 +17,22 @@
 
 <h1>Kodeks postępowania współtwórców</h1>
 
-<P>My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez "pull request".</P>
+<P>My, współtwórcy, działając dla dobra oraz otwartości naszej społeczności, ślubujemy poszanowanie dla wszystkich osób, które wnoszą wkład do naszej pracy poprzez: zgłaszanie problemów, propozycji zmian, aktualizację dokumentacji, czy zgłaszanie poprawek poprzez pull request.</P>
 
 <P>Pragniemy, aby udział w projekcie był pozbawiony szykanowania ze względu na doświadczenie, płeć, orientację i identyfikację seksualną, stopień niepełnosprawności, wygląd, budowę ciała, kolor skóry, pochodzenie, czy wiek.</P>
 
-<P>Wśród przykładów zachowania którego nie będziemy akceptować są:</P>
+<P>Wśród przykładów zachowania, którego nie będziemy akceptować, są:</P>
 <ul>
 <li>Używanie seksualnego języka i grafik,</li>
 <li>Ataki osobiste,</li>
-<li>"Trollowanie" i obraźliwe bądź urągające komentarze,</li>
+<li>Trollowanie i obraźliwe bądź urągające komentarze,</li>
 <li>Zastraszanie, tak na forum publicznym jak i prywatne,</li>
 <li>Publikowanie bez wyraźnej zgody informacji osobistych, takich jak: adres
 fizyczny czy elektroniczny,</li>
 <li>Inne nieetyczne lub nieprofesjonalne zachowania.</li>
 </ul>
 
-<P>Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do "banowania", tak tymczasowego jak i stałego, osób których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.</P>
+<P>Opiekunowie projektu zastrzegają sobie prawo do usuwania, edycji oraz odrzucania: komentarzy, commitów, kodu, wpisów na wiki oraz innych treści które łamią niniejszy Kodeks Postępowania. Ponadto zastrzegają sobie prawo do banowania — tak tymczasowego jak i stałego — osób, których zachowania uznają za: niestosowne, zastraszające, obraźliwe lub szkodliwe.</P>
 
 <P>Poprzez przyjęcie niniejszego Kodeksu postępowania opiekunowie ślubują, że będą cechować się uczciwością oraz konsekwentnością przy stosowaniu tych zasad w każdym aspekcie swojego działania nad tym projektem. Opiekunowie, który nie będą postępować lub wymagać od innych zachowania zgodnego z Kodeksem mogą zostać stale usunięci z zespołu współtworzącego ten projekt.</P>
 


### PR DESCRIPTION
(The correct spelling is “polski”, but it looks bad alongside other languages starting with capital letters.  This is a personal opinion that other people may override.)