### PR TITLE
Fix double-close of <link> tags.

### DIFF
--- a/version/1/3/0/index.htm
+++ b/version/1/3/0/index.htm
@@ -14,8 +14,8 @@
     }
   </style>
   <link rel="alternate" hreflang="es" href="version/1/3/0/es/" />
-  <link rel="alternate" hreflang="fr" href="version/1/3/0/fr/"> />
-  <link rel="alternate" hreflang="it" href="version/1/3/0/it/"> />
+  <link rel="alternate" hreflang="fr" href="version/1/3/0/fr/" />
+  <link rel="alternate" hreflang="it" href="version/1/3/0/it/" />
   <link rel="alternate" hreflang="hu" href="version/1/3/0/hu/" />
   <link rel="alternate" hreflang="pl" href="version/1/3/0/pl/" />
   <link rel="alternate" hreflang="pt" href="version/1/3/0/pt/" />


### PR DESCRIPTION
There was an HTML error where "/>" appeared twice at the top of the
page because the <link> tags in the head section were closed twice.
This fixes the problem.

Problem can be seen at the time of writing [on the contributor covenant
website](http://contributor-covenant.org/version/1/3/0/).