### PR TITLE
Add Solidus to Contributor Covenant List

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ This code of conduct has been adopted by [thousands of open source projects](htt
 * [Shoes](https://github.com/shoes/shoes4)
 * [Snuffle](https://gitlab.com/coraline/snuffle/tree/master)
 * [Snipe-IT](https://github.com/snipe/snipe-it)
+* [Solidus](https://github.com/solidusio/solidus)
 * [Spree](https://github.com/spree/spree)
 * [vim cheat sheet](https://github.com/rtorr/vim-cheat-sheet)
 * [vim-devicons](https://github.com/ryanoasis/vim-devicons)

--- a/adopters/index.html
+++ b/adopters/index.html
@@ -88,6 +88,7 @@
       <li><a href="https://github.com/rubygems/rubygems.org">RubyGems.org</a></li>
       <li><a href="https://github.com/rvm/rvm">RVM</a></li>
       <li><a href="https://github.com/ReactiveX/RxJS">ReactiveX/RxJS</a></li>
+      <li><a href="https://github.com/solidusio/solidus">Solidus</a></li>
       <li><a href="https://github.com/spree/spree">Spree</a></li>
       <li><a href="https://github.com/qa-tools/qa-tools">QA-Tools</a></li>
       <li><a href="https://gitlab.com/coraline/snuffle/tree/master">Snuffle</a></li>

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
 			<li><a href="https://github.com/rubygems/rubygems.org">RubyGems.org</a></li>
 			<li><a href="https://github.com/rvm/rvm">RVM</a></li>
 			<li><a href="https://github.com/shoes/shoes4">Shoes</a></li>
-			<li><a href="https://github.com/spree/spree">Spree</a></li>
+			<li><a href="https://github.com/solidusio/solidus">Solidus</a></li>
 			<li><a href="https://swift.org/community/#code-of-conduct">Swift</a></li>
       <li><a href="https://www.tinymce.com/docs/advanced/contributing-to-open-source/">TinyMCE</a></li>
 			<li><a href="https://github.com/Microsoft/visualfsharp">Visual F#</a></li>


### PR DESCRIPTION
Added Solidus to the list in the README.

See https://github.com/solidusio/solidus/pull/643 for the Code of Conduct PR.

For the index page, I've replaced Spree with Solidus. Spree got rebranded to Solidus since Spreecommerce could no longer look after it. The community took the reigns after and rebranded it to Solidus.

See https://github.com/spree/spree/pull/6881 for maintenance information on Spree.