### PR TITLE
Link to Ashe's 101 + FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,8 @@
 		<p>An easy way to begin addressing this problem is to be overt in our openness, welcoming all people to contribute, and pledging in return to value them as human beings and to foster an atmosphere of kindness, cooperation, and understanding.</p>
 
 		<p>The Contributor Covenant can be one way to express these values. Pledge your respect and appreciation for contributors and participants in your open source project by adding an explicit CODE_OF_CONDUCT.md to your project repository.</p>
-
+		
+		<p>(While being more suited to Codes of Conduct in conferences, this <a href="http://www.ashedryden.com/blog/codes-of-conduct-101-faq">101 + FAQ</a> addresses many of the common questions and arguments around this topic.)</p>
 	</section>
 
 	<section id="where">


### PR DESCRIPTION
I'm not entirely sure this is the best place to add this in the page, but I thought it would be a great idea to link to Ashe Dryden's 101 + FAQ on Codes of Conduct.

While it's written in the context of CoC's at events, it clarifies many of the common questions and arguments around all of these topics, and it's always been one of my goto resources whenever someone decides to come up with the usual arguments against codes of conduct.