### PR TITLE
Add Active Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This code of conduct has been adopted by [thousands of open source projects](htt
 
 * [24 Pull Requests](https://github.com/24pullrequests/24pullrequests)
 * [AASM](https://github.com/aasm/aasm)
+* [Active Admin](https://github.com/activeadmin/activeadmin)
 * [Algorrent](https://github.com/algorrent/algorrent)
 * [All HaskellNow.org Projects](http://www.haskellnow.org/wiki/WikiStart#Projects)
 * [AngularJS](https://github.com/angular/code-of-conduct)

--- a/adopters/index.html
+++ b/adopters/index.html
@@ -30,6 +30,7 @@
 		<ul class="medium-break-two large-break-three">
 			<li><a href="https://github.com/24pullrequests/24pullrequests">24 Pull Requests</a></li>
 			<li><a href="https://github.com/aasm/aasm">AASM</a></li>
+			<li><a href="https://github.com/activeadmin/activeadmin">Active Admin</a></li>
 			<li><a href="https://github.com/algorrent/algorrent">Algorrent</a></li>
 			<li><a href="https://github.com/angular/code-of-conduct">AngularJS</a></li>
 			<li><a href="https://github.com/formly-js/angular-formly">angular-formly</a></li>


### PR DESCRIPTION
Active Admin is a tool built on Rails that lets you easily build an administration UI for your existing website.

We've accepted this CoC into the project where there was none before: https://github.com/activeadmin/activeadmin/pull/4180