### PR TITLE
Change Lotus to Hanami, because it's been renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This code of conduct has been adopted by [thousands of open source projects](htt
 * [lfda](https://github.com/terrytangyuan/lfda)
 * [Jekyll](https://github.com/jekyll/jekyll)
 * [JRuby-Gradle](https://github.com/jruby-gradle/jruby-gradle-plugin)
-* [Lotus](http://lotusrb.org/community#code-of-conduct)
+* [Hanami](http://hanamirb.org/community#code-of-conduct)
 * [Mensa](https://github.com/jordanekay/Mensa)
 * [MeTal](https://github.com/syegulalp/MeTal)
 * [Mono](http://mono-project.com)

--- a/adopters/index.html
+++ b/adopters/index.html
@@ -72,7 +72,7 @@
 			<li><a href="https://github.com/julianguyen/ifme">if me</a></li>
 			<li><a href="https://github.com/jekyll/jekyll">Jeckyll</a></li>
 			<li><a href="https://jenkins-ci.org/conduct/">Jenkins</a></li>
-			<li><a href="http://lotusrb.org/community#code-of-conduct">Lotus</a></li>
+			<li><a href="http://hanamirb.org/community#code-of-conduct">Hanami</a></li>
 			<li><a href="https://github.com/jordanekay/Mensa">Mensa</a></li>
 			<li><a href="https://github.com/rapid7/metasploit-framework">Metasploit</a></li>
 			<li><a href="https://github.com/mono/mono">Mono</a></li>

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
 			<li><a href="https://github.com/caskroom/homebrew-cask">Homebrew-Cask</a></li>
 			<li><a href="https://github.com/jekyll/jekyll">Jekyll</a></li>
 			<li><a href="https://jenkins-ci.org/conduct/">Jenkins</a></li>
-			<li><a href="http://lotusrb.org/community#code-of-conduct">Lotus</a></li>
+			<li><a href="http://hanamirb.org/community#code-of-conduct">Hanami</a></li>
 			<li><a href="https://github.com/rapid7/metasploit-framework">Metasploit Framework</a></li>
 			<li><a href="https://github.com/mono/mono">Mono</a></li>
 			<li><a href="https://www.webmaker.org/">Mozilla Webmaker</a></li>


### PR DESCRIPTION
See [Lotus is now Hanami](http://hanamirb.org/blog/2016/01/22/lotus-is-now-hanami.html). :cherry_blossom: :cherry_blossom: :cherry_blossom:  :v: 