### PR TITLE
Add Squirrel.Windows and ReactiveUI to adopters page

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -103,12 +103,14 @@
 			<li><a href="https://github.com/rubygems/rubygems.org">RubyGems.org</a></li>
 			<li><a href="https://github.com/rvm/rvm">RVM</a></li>
 			<li><a href="https://github.com/ReactiveX/RxJS">ReactiveX/RxJS</a></li>
+			<li><a href="https://github.com/reactiveui/reactiveui">ReactiveUI</a></li>
 			<li><a href="https://github.com/spree/spree">Spree</a></li>
 			<li><a href="https://github.com/qa-tools/qa-tools">QA-Tools</a></li>
 			<li><a href="https://github.com/sassdoc/sassdoc">SassDoc</a></li>
 			<li><a href="https://github.com/HugoGiraudel/sass-guidelines">Sass Guidelines</a></li>
 			<li><a href="https://gitlab.com/coraline/snuffle/tree/master">Snuffle</a></li>
 			<li><a href="https://github.com/snipe/snipe-it">Snipe-IT</a></li>
+			<li><a href="https://github.com/squirrel/squirrel.windows">Squirrel for Windows</a></li>
 			<li><a href="https://swift.org/community/#code-of-conduct">Swift</a></li>
 			<li><a href="https://github.com/taigaio/code-of-conduct">Taiga.io</a></li>
 			<li><a href="https://www.tinymce.com/docs/advanced/contributing-to-open-source/">TinyMCE</a></li>


### PR DESCRIPTION
Here's a PR to add some of my more popular projects (>1000 :star2:s) onto the adopters page, though every non-trivial repo I've created now has the CC. Thanks again for the enormous amount of work you're doing for the OSS community, this is really huge.